### PR TITLE
Add the ability to query status for a PR

### DIFF
--- a/scripts/pr-status.coffee
+++ b/scripts/pr-status.coffee
@@ -29,4 +29,4 @@ module.exports = (robot) ->
     github.get pull_url, (pull) ->
       github.get pull.statuses_url, (status) ->
         last_status = status[0]
-        msg.send "#{pull.html_url} - #{last_status.state} - #{last_status.description}"
+        msg.send "#{last_status.state} - #{last_status.target_url}"


### PR DESCRIPTION
Fixes #1 

Example:

`hubot status jekyll/jekyll 1993` will give you back

```
success - https://travis-ci.org/jekyll/jekyll/builds/17655056
```
