### PR TITLE
Allow no repo to be specified for /status

### DIFF
--- a/scripts/pr-status.coffee
+++ b/scripts/pr-status.coffee
@@ -10,7 +10,8 @@
 #   HUBOT_GITHUB_API
 #
 # Commands:
-#   hubot repo show <repo> - shows activity of repository
+#   hubot status jekyll/jekyll 2004
+#   hubot status 2004
 #
 # Notes:
 #   HUBOT_GITHUB_API allows you to set a custom URL path (for Github enterprise users)


### PR DESCRIPTION
This PR allows the user to [omit the repo name](http://rubular.com/r/uuVFSH6etZ).

`githubot` will [automatically assign the repo](https://github.com/iangreenleaf/githubot/blob/master/githubot.coffee#L14-L18) when it's specified in the ENV. Currently set to `jekyll/jekyll` on our instance.

This means the following are equivalent:

``` text
/status jekyll/jekyll 2004
/status 2004
```

iff `HUBOT_GITHUB_REPO` is set to `jekyll/jekyll`.
